### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,23 @@
 		</license>
 	</licenses>
 
+	<properties>
+			<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+			<junit.version>5.6.2</junit.version>
+			<bouncycastle.version>1.65</bouncycastle.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
-			<scope>test</scope>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.48</version>
+			<version>${bouncycastle.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -57,10 +63,12 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
+				<version>4.2.1</version>
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M4</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -79,7 +87,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
+						<version>3.2.1</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -92,7 +100,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version>
+						<version>3.2.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -105,7 +113,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -119,7 +127,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.3</version>
+						<version>1.6.8</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>

--- a/src/main/java/org/jitsi/bccontrib/prng/FortunaGenerator.java
+++ b/src/main/java/org/jitsi/bccontrib/prng/FortunaGenerator.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.digests.SHA256Digest;
-import org.bouncycastle.crypto.engines.AESFastEngine;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.crypto.prng.RandomGenerator;
 
@@ -159,7 +159,7 @@ public class FortunaGenerator implements RandomGenerator {
     }
     
     public FortunaGenerator(byte[] seed) {
-        generator = new Generator(new AESFastEngine(), new SHA256Digest());
+        generator = new Generator(new AESEngine(), new SHA256Digest());
         pools = new Digest[NUM_POOLS];
         for (int i = 0; i < NUM_POOLS; i++)
             pools[i] = new SHA256Digest();

--- a/src/test/java/org/jitsi/bccontrib/tests/SkeinTest.java
+++ b/src/test/java/org/jitsi/bccontrib/tests/SkeinTest.java
@@ -26,6 +26,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 package org.jitsi.bccontrib.tests;
 
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Scanner;
@@ -35,9 +37,8 @@ import org.jitsi.bccontrib.digests.Skein;
 import org.jitsi.bccontrib.macs.SkeinMac;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.jitsi.bccontrib.params.ParametersForSkein;
-
-import static org.junit.Assert.assertTrue;
-import org.junit.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SkeinTest {
 
@@ -102,7 +103,7 @@ public class SkeinTest {
         return true;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         InputStream file = getClass().getResourceAsStream("/skein_golden_kat.txt");
         scanner = new KatScanner(file);

--- a/src/test/java/org/jitsi/bccontrib/tests/ThreefishTest.java
+++ b/src/test/java/org/jitsi/bccontrib/tests/ThreefishTest.java
@@ -1,14 +1,14 @@
 package org.jitsi.bccontrib.tests;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 
 import org.jitsi.bccontrib.engines.ThreefishCipher;
 import org.bouncycastle.crypto.params.*;
 import org.jitsi.bccontrib.params.ParametersForThreefish;
 import org.jitsi.bccontrib.util.ByteLong;
-
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThreefishTest {
 
@@ -315,7 +315,8 @@ public class ThreefishTest {
         return true;
     }
 
-    @Test public void vectorTest() {
+    @Test
+    public void vectorTest() {
         try {
             assertTrue(basicTest256());
             assertTrue(basicTest512());


### PR DESCRIPTION
This PR updates the dependencies to their latest versions, fixes maven warnings, migrates the tests from Junit 4 to Junit 5 and  replaces the deprecated AESFastEngine with AESEngine 😃 